### PR TITLE
publish docker images to quay.io as well

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        IMAGE_NAME: ${{ env.DOCKER_IMAGE }}
+        IMAGE_NAME: "${{ env.DOCKER_IMAGE }}"
         ADDITIONAL_TAG: ${{ steps.calver.outputs.version }}
 
     - name: Also Push To quay.io

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         image: ${DOCKER_IMAGE}
         tags: ${{ steps.calver.outputs.version }}
-        registry: quay.io/${{ secrets.QUAY_USERNAME }}
+        registry: quay.io/uwhackweek
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,14 +27,14 @@ jobs:
       with:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        IMAGE_NAME: ${DOCKER_IMAGE}
+        IMAGE_NAME: ${{ env.DOCKER_IMAGE }}
         ADDITIONAL_TAG: ${{ steps.calver.outputs.version }}
 
     - name: Also Push To quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${DOCKER_IMAGE}
+        image: ${{ env.DOCKER_IMAGE }}
         tags: ${{ steps.calver.outputs.version }}
         registry: quay.io/uwhackweek
         username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,9 +8,6 @@ on:
       - 'README.md'
       - '.gitignore'
 
-env:
-  DOCKER_IMAGE: uwhackweek/template
-
 jobs:
   build-image-and-push:
     runs-on: ubuntu-latest
@@ -27,14 +24,14 @@ jobs:
       with:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        IMAGE_NAME: "${{ env.DOCKER_IMAGE }}"
+        IMAGE_NAME: uwhackweek/template
         ADDITIONAL_TAG: ${{ steps.calver.outputs.version }}
 
     - name: Also Push To quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ env.DOCKER_IMAGE }}
+        image: uwhackweek/template
         tags: ${{ steps.calver.outputs.version }}
         registry: quay.io/uwhackweek
         username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
       - 'README.md'
       - '.gitignore'
 
+env:
+  DOCKER_IMAGE: uwhackweek/template
+
 jobs:
   build-image-and-push:
     runs-on: ubuntu-latest
@@ -24,14 +27,14 @@ jobs:
       with:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        IMAGE_NAME: uwhackweek/template
+        IMAGE_NAME: ${{ env.DOCKER_IMAGE }}
         ADDITIONAL_TAG: ${{ steps.calver.outputs.version }}
 
     - name: Also Push To quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: uwhackweek/template
+        image: ${{ env.DOCKER_IMAGE }}
         tags: ${{ steps.calver.outputs.version }}
         registry: quay.io/uwhackweek
         username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
       - 'README.md'
       - '.gitignore'
 
+env:
+  DOCKER_IMAGE: uwhackweek/template
+
 jobs:
   build-image-and-push:
     runs-on: ubuntu-latest
@@ -19,15 +22,29 @@ jobs:
       id: calver
       run: echo "::set-output name=version::$(date +'%Y.%m.%d')"
 
-    - name: Build and Push
+    - name: Build and Push to DockerHub
       uses: jupyterhub/repo2docker-action@master
       with:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        IMAGE_NAME: "uwhackweek/template"
+        IMAGE_NAME: ${DOCKER_IMAGE}
         ADDITIONAL_TAG: ${{ steps.calver.outputs.version }}
 
+    - name: Also Push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${DOCKER_IMAGE}
+        tags: ${{ steps.calver.outputs.version }}
+        registry: quay.io/${{ secrets.QUAY_USERNAME }}
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
     - name: Report Image Size and Conda Packages
+      if: always()
       run: |
         docker images
         docker run uwhackweek/template:latest conda list --export

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -22,9 +22,9 @@ jobs:
       uses: jupyterhub/repo2docker-action@master
       with:
         NO_PUSH: 'true'
-        IMAGE_NAME: ${DOCKER_IMAGE}
+        IMAGE_NAME: ${{ env.DOCKER_IMAGE }}
 
     - name: Report Image Size and Conda Packages
       run: |
         docker images
-        docker run ${DOCKER_IMAGE}:latest conda list --export
+        docker run ${{ env.DOCKER_IMAGE }}:latest conda list --export

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -7,6 +7,10 @@ on:
       - 'LICENSE'
       - 'README.md'
       - '.gitignore'
+
+env:
+  DOCKER_IMAGE: uwhackweek/template
+
 jobs:
   build-image-without-pushing:
     runs-on: ubuntu-latest
@@ -18,9 +22,9 @@ jobs:
       uses: jupyterhub/repo2docker-action@master
       with:
         NO_PUSH: 'true'
-        IMAGE_NAME: "uwhackweek/template"
+        IMAGE_NAME: ${DOCKER_IMAGE}
 
     - name: Report Image Size and Conda Packages
       run: |
         docker images
-        docker run uwhackweek/template:latest conda list --export
+        docker run ${DOCKER_IMAGE}:latest conda list --export

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -28,3 +28,10 @@ jobs:
       run: |
         docker images
         docker run ${{ env.DOCKER_IMAGE }}:latest conda list --export
+        docker run ${{ env.DOCKER_IMAGE }}:latest conda list --explicit > conda-linux-64.lock
+
+    - name: Save package list
+      uses: actions/upload-artifact@v2
+      with:
+        name: packages
+        path: conda-linux-64.lock

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Save package list
       uses: actions/upload-artifact@v2
       with:
-        name: packages
+        name: lockfile
         path: conda-linux-64.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+
+services:
+  jupyterlab:
+    image: "uwhackweek/template:latest"
+    ports:
+      - "8888:8888"
+    command: "jupyter lab --ip 0.0.0.0 --no-browser"
+    volumes:
+      - ${PWD}:/home/jovyan

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - jupyter-book=0.10
   - jupyterlab=3
   - jupyter-resource-usage
+  - sphinxcontrib-bibtex=2.2

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ipyleaflet
-  - jupyter-book=0.10.2
+  - jupyter-book=0.10
   - jupyterlab=3
   - jupyter-resource-usage
-  - sphinxcontrib-bibtex=2.2
+  - sphinxcontrib-bibtex=2

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ipyleaflet
-  - jupyter-book=0.10
+  - jupyter-book=0.10.2
   - jupyterlab=3
   - jupyter-resource-usage
   - sphinxcontrib-bibtex=2.2


### PR DESCRIPTION
see https://github.com/jupyterhub/repo2docker-action#push-image-to-quayio 

but we want to push these to both dockerhub and quay and possibly others in the future so we'll use this https://github.com/marketplace/actions/push-to-registry 

to do this manually:
```
docker login quay.io
#Username: ROBOT USER NAME
#Password:  ROBOT ACCESS TOKEN
docker tag uwhackweek/template:latest  quay.io/uwhackweek/template:latest 
docker push quay.io/uwhackweek/template:latest 
```